### PR TITLE
Create first draft of text-based page

### DIFF
--- a/assets/css/_sass/_text.scss
+++ b/assets/css/_sass/_text.scss
@@ -1,17 +1,30 @@
 .text-main-content {
-
+	position: relative;
+	display: grid;
+	grid-template-areas: "type" "title" "metadata" "content";
+	padding: 1em 4.167%;
+	@media screen and (min-width: 600px) {
+		padding: 1em 8.33%;
+	}
 }
 
 .text__page-type {
-
+	grid-area: type;
+	display: none;
 }
 
 .text__metadata {
-
+	grid-area: metadata;
 }
 
-.text-meta__title {
-
+.text__title {
+	grid-area: title;
+	margin-bottom: .5em;
+	margin-top: 1em;
+//	font-family: "Raleway", sans-serif;
+	font-size: 3rem;
+	font-weight: 900;
+//	text-transform: uppercase;
 }
 
 .text-meta__author {
@@ -27,5 +40,5 @@
 }
 
 .text__content {
-
+	grid-area: content;
 }

--- a/assets/css/_sass/_text.scss
+++ b/assets/css/_sass/_text.scss
@@ -1,0 +1,31 @@
+.text-main-content {
+
+}
+
+.text__page-type {
+
+}
+
+.text__metadata {
+
+}
+
+.text-meta__title {
+
+}
+
+.text-meta__author {
+
+}
+
+.text-meta__date {
+
+}
+
+.text-meta__categories {
+
+}
+
+.text__content {
+
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -4,6 +4,7 @@
 @import "sections";
 @import "footer";
 @import "item";
+@import "text";
 
 /* Universal Styles: */
 

--- a/pages/text.html
+++ b/pages/text.html
@@ -22,6 +22,7 @@ punchy-quote: Text content of section two. Blah blah blah. Donec molestie fermen
 
 	<div class="text__metadata">
 		<div class="text-meta__title">{{ page.post-title }}</div>
+		<div class="text-meta__categories">&ldquo;{{ page.punchy-quote }}&rdquo;</div>
 		<div class="text-meta__author">By <a href="#">{{ page.author }}</a></div>
 		<div class="text-meta__date">Posted {{ site.time | date: "%B %d, %Y" }}</div>
 		<div class="text-meta__categories">Filed under:
@@ -31,7 +32,6 @@ punchy-quote: Text content of section two. Blah blah blah. Donec molestie fermen
 			{% else %} <a href="#">{{ c }}</a>,
 			{% endif %}{% endfor %}
 		</div>
-		<div class="text-meta__categories">&ldquo;{{ page.punchy-quote }}&rdquo;</div>
 	</div>
 
 	<div class="text__content">

--- a/pages/text.html
+++ b/pages/text.html
@@ -20,8 +20,9 @@ punchy-quote: Text content of section two. Blah blah blah. Donec molestie fermen
 
 	<div class="text__page-type">Text Page</div>
 
+	<div class="text__title">{{ page.post-title }}</div>
+
 	<div class="text__metadata">
-		<div class="text-meta__title">{{ page.post-title }}</div>
 		<div class="text-meta__categories">&ldquo;{{ page.punchy-quote }}&rdquo;</div>
 		<div class="text-meta__author">By <a href="#">{{ page.author }}</a></div>
 		<div class="text-meta__date">Posted {{ site.time | date: "%B %d, %Y" }}</div>

--- a/pages/text.html
+++ b/pages/text.html
@@ -5,7 +5,15 @@ permalink: /text/
 # test vars:
 post-title: Text-Based Page, Like a Blog Post
 author: Katherine Donnally
-categories: tutorials, ice cream, dogs
+categories: 
+- tutorials
+- ice cream
+- dogs
+# punchy quote or sentence-ish summary of article.
+# (Gives little preview for readers who aren't sure whether to
+# delve in based on the title alone, or as another hook for
+# something that might've been too long for the title.)
+punchy-quote: Text content of section two. Blah blah blah. Donec molestie fermentum lorem eu laoreet.
 ---
 
 <div class="text-main-content" aria-label="Main content">
@@ -14,9 +22,16 @@ categories: tutorials, ice cream, dogs
 
 	<div class="text__metadata">
 		<div class="text-meta__title">{{ page.post-title }}</div>
-		<div class="text-meta__author">{{ page.author }}</div>
-		<div class="text-meta__date">{{ site.time | date: "%B %d, %Y" }}</div>
-		<div class="text-meta__categories">Create categories loop here!</div>
+		<div class="text-meta__author">By <a href="#">{{ page.author }}</a></div>
+		<div class="text-meta__date">Posted {{ site.time | date: "%B %d, %Y" }}</div>
+		<div class="text-meta__categories">Filed under:
+			{% for c in page.categories %}
+			{% assign last = page.categories | last %}
+			{% if c == last %} <a href="#">{{ c }}</a>
+			{% else %} <a href="#">{{ c }}</a>,
+			{% endif %}{% endfor %}
+		</div>
+		<div class="text-meta__categories">&ldquo;{{ page.punchy-quote }}&rdquo;</div>
 	</div>
 
 	<div class="text__content">

--- a/pages/text.html
+++ b/pages/text.html
@@ -1,0 +1,28 @@
+---
+layout: no-header
+title: Text
+permalink: /text/
+# test vars:
+post-title: Text-Based Page, Like a Blog Post
+author: Katherine Donnally
+categories: tutorials, ice cream, dogs
+---
+
+<div class="text-main-content" aria-label="Main content">
+
+	<div class="text__page-type">Text Page</div>
+
+	<div class="text__metadata">
+		<div class="text-meta__title">{{ page.post-title }}</div>
+		<div class="text-meta__author">{{ page.author }}</div>
+		<div class="text-meta__date">{{ site.time | date: "%B %d, %Y" }}</div>
+		<div class="text-meta__categories">Create categories loop here!</div>
+	</div>
+
+	<div class="text__content">
+		<p>Text content of section one. Blah blah blah. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non iaculis enim, et porta lectus. Duis non quam ornare, euismod leo nec, posuere mauris. Pellentesque sed varius ipsum, luctus pharetra nibh. Vestibulum ante sapien, posuere non metus sed, eleifend vulputate lorem. Vivamus elementum mollis turpis.</p>
+		<p>Text content of section two. Blah blah blah. Donec molestie fermentum lorem eu laoreet. Fusce id urna eu lectus eleifend rhoncus nec ac nulla. Donec dui ligula, ultrices at luctus sed, mollis eu nibh. Nunc tincidunt, felis ac consectetur ultricies, neque tortor gravida nibh, sodales cursus massa tellus eu sapien. Suspendisse dolor velit, venenatis quis sodales ut, pellentesque at enim. Integer feugiat, dui id sollicitudin auctor, tellus nulla ullamcorper erat, nec porta velit diam congue lectus. Pellentesque et quam sed lectus semper egestas. Quisque augue magna, imperdiet id augue eu, sollicitudin vestibulum nulla.</p>
+		<p>Text content of section three. Blah blah blah. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed non iaculis enim, et porta lectus. Duis non quam ornare, euismod leo nec, posuere mauris. Pellentesque sed varius ipsum, luctus pharetra nibh. Vestibulum ante sapien, posuere non metus sed, eleifend vulputate lorem. Vivamus elementum mollis turpis.</p>
+		<p>Text content of section four. Blah blah blah. Morbi sed turpis vitae est fringilla posuere ac id ante. Aenean eu diam eu ligula viverra dignissim eu a tortor. Phasellus vestibulum augue turpis, sed mollis sem interdum at. Aliquam libero orci, vulputate eu velit nec, aliquam dignissim tortor. Maecenas id neque ultrices, scelerisque felis id, placerat arcu.</p>
+	</div>
+</div>

--- a/testing/html-to-classes.py
+++ b/testing/html-to-classes.py
@@ -48,7 +48,7 @@ def classesToCSS(class_names):
 pattern = r'class=".*?"'
 
 # list of all 'class="<val>"' in file
-matches = regexTextSearch('../pages/single-item.html', pattern)
+matches = regexTextSearch('../pages/text.html', pattern)
 
 # list of all val for 'class="<val>"' in matches
 class_names = stripClassStrings(matches)


### PR DESCRIPTION
# Description
- Create HTML structure for a text-based page (e.g. blog post)
- HTML contains Liquid templating that'll allow for variable content within such a post using YAML front-matter variables. Currently demonstrated with dummy variables in the document.
 - NB: This is for Jekyll sites, but could easily be converted to other templating languages.
- CSS is not so pretty - that felt pretty context-dependent, & I realized I wanted to test that on the SLab site rather than trying to guess how a generic "text-based page" might best look.
 - Will update with more polished styles once created on the SLab site.
