### PR TITLE
Create dynamically-resized top navigation menu

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,6 +15,9 @@
 
     {%- include footer.html -%}
 
+    <script src="{{ '/assets/js/main.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ '/assets/js/lib/hammer.min.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
+
   </body>
 
 </html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,10 +7,8 @@
 
     {%- include navbar.html -%}
 
-    <main class="page-content" aria-label="Content">
-      <div class="wrapper">
-        {{ content }}
-      </div>
+    <main id="main" role="main">
+      {{ content }}
     </main>
 
     {%- include footer.html -%}

--- a/_layouts/no-header.html
+++ b/_layouts/no-header.html
@@ -10,8 +10,8 @@
 
     {% include footer.html %}
 
-    <script src="{{ site.baseurl }}/assets/js/main.js" type="text/javascript" charset="utf-8"></script>
-    <script src="{{ site.baseurl }}/assets/js/lib/hammer.min.js" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ '/assets/js/main.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
+    <script src="{{ '/assets/js/lib/hammer.min.js' | relative_url }}" type="text/javascript" charset="utf-8"></script>
 
   </body>
 

--- a/_posts/2018-01-05-the-proposal-begins.md
+++ b/_posts/2018-01-05-the-proposal-begins.md
@@ -2,8 +2,8 @@
 layout: post
 title: Explainers
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 It is a melancholy object to those who walk through this great town or travel in the country, when they see the streets, the roads, and cabin doors, crowded with beggars of the female sex, followed by three, four, or six children, all in rags and importuning every passenger for an alms. These mothers, instead of being able to work for their honest livelihood, are forced to employ all their time in strolling to beg sustenance for their helpless infants: who as they grow up either turn thieves for want of work, or leave their dear native country to fight for the Pretender in Spain, or sell themselves to the Barbadoes.

--- a/_posts/2018-01-05-the-proposal-begins.md
+++ b/_posts/2018-01-05-the-proposal-begins.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Explainers
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+It is a melancholy object to those who walk through this great town or travel in the country, when they see the streets, the roads, and cabin doors, crowded with beggars of the female sex, followed by three, four, or six children, all in rags and importuning every passenger for an alms. These mothers, instead of being able to work for their honest livelihood, are forced to employ all their time in strolling to beg sustenance for their helpless infants: who as they grow up either turn thieves for want of work, or leave their dear native country to fight for the Pretender in Spain, or sell themselves to the Barbadoes.
+
+I think it is agreed by all parties that this prodigious number of children in the arms, or on the backs, or at the heels of their mothers, and frequently of their fathers, is in the present deplorable state of the kingdom a very great additional grievance; and, therefore, whoever could find out a fair, cheap, and easy method of making these children sound, useful members of the commonwealth, would deserve so well of the public as to have his statue set up for a preserver of the nation.

--- a/_posts/2018-02-11-it-will-help-beggars.md
+++ b/_posts/2018-02-11-it-will-help-beggars.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Politics & Policy
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+But my intention is very far from being confined to provide only for the children of professed beggars; it is of a much greater extent, and shall take in the whole number of infants at a certain age who are born of parents in effect as little able to support them as those who demand our charity in the streets.
+
+As to my own part, having turned my thoughts for many years upon this important subject, and maturely weighed the several schemes of other projectors, I have always found them grossly mistaken in the computation. It is true, a child just dropped from its dam may be supported by her milk for a solar year, with little other nourishment; at most not above the value of 2s., which the mother may certainly get, or the value in scraps, by her lawful occupation of begging; and it is exactly at one year old that I propose to provide for them in such a manner as instead of being a charge upon their parents or the parish, or wanting food and raiment for the rest of their lives, they shall on the contrary contribute to the feeding, and partly to the clothing, of many thousands.

--- a/_posts/2018-02-11-it-will-help-beggars.md
+++ b/_posts/2018-02-11-it-will-help-beggars.md
@@ -2,8 +2,8 @@
 layout: post
 title: Politics & Policy
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 But my intention is very far from being confined to provide only for the children of professed beggars; it is of a much greater extent, and shall take in the whole number of infants at a certain age who are born of parents in effect as little able to support them as those who demand our charity in the streets.

--- a/_posts/2018-02-16-mike-pence-approves.md
+++ b/_posts/2018-02-16-mike-pence-approves.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: World
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+There is likewise another great advantage in my scheme, that it will prevent those voluntary abortions, and that horrid practice of women murdering their bastard children, alas! too frequent among us! sacrificing the poor innocent babes I doubt more to avoid the expense than the shame, which would move tears and pity in the most savage and inhuman breast.
+
+The number of souls in this kingdom being usually reckoned one million and a half, of these I calculate there may be about two hundred thousand couple whose wives are breeders; from which number I subtract thirty thousand couples who are able to maintain their own children, although I apprehend there cannot be so many, under the present distresses of the kingdom; but this being granted, there will remain an hundred and seventy thousand breeders. I again subtract fifty thousand for those women who miscarry, or whose children die by accident or disease within the year. There only remains one hundred and twenty thousand children of poor parents annually born. The question therefore is, how this number shall be reared and provided for, which, as I have already said, under the present situation of affairs, is utterly impossible by all the methods hitherto proposed. For we can neither employ them in handicraft or agriculture; we neither build houses (I mean in the country) nor cultivate land: they can very seldom pick up a livelihood by stealing, till they arrive at six years old, except where they are of towardly parts, although I confess they learn the rudiments much earlier, during which time, they can however be properly looked upon only as probationers, as I have been informed by a principal gentleman in the county of Cavan, who protested to me that he never knew above one or two instances under the age of six, even in a part of the kingdom so renowned for the quickest proficiency in that art.

--- a/_posts/2018-02-16-mike-pence-approves.md
+++ b/_posts/2018-02-16-mike-pence-approves.md
@@ -2,8 +2,8 @@
 layout: post
 title: World
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 There is likewise another great advantage in my scheme, that it will prevent those voluntary abortions, and that horrid practice of women murdering their bastard children, alas! too frequent among us! sacrificing the poor innocent babes I doubt more to avoid the expense than the shame, which would move tears and pity in the most savage and inhuman breast.

--- a/_posts/2018-02-19-were-gonna-have-to-eat-the-kids.md
+++ b/_posts/2018-02-19-were-gonna-have-to-eat-the-kids.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: Culture
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+I am assured by our merchants, that a boy or a girl before twelve years old is no salable commodity; and even when they come to this age they will not yield above three pounds, or three pounds and half-a-crown at most on the exchange; which cannot turn to account either to the parents or kingdom, the charge of nutriment and rags having been at least four times that value.
+
+I shall now therefore humbly propose my own thoughts, which I hope will not be liable to the least objection.
+
+I have been assured by a very knowing American of my acquaintance in London, that a young healthy child well nursed is at a year old a most delicious, nourishing, and wholesome food, whether stewed, roasted, baked, or boiled; and I make no doubt that it will equally serve in a fricassee or a ragout.
+
+I do therefore humbly offer it to public consideration that of the hundred and twenty thousand children already computed, twenty thousand may be reserved for breed, whereof only one-fourth part to be males; which is more than we allow to sheep, black cattle or swine; and my reason is, that these children are seldom the fruits of marriage, a circumstance not much regarded by our savages, therefore one male will be sufficient to serve four females. That the remaining hundred thousand may, at a year old, be offered in the sale to the persons of quality and fortune through the kingdom; always advising the mother to let them suck plentifully in the last month, so as to render them plump and fat for a good table. A child will make two dishes at an entertainment for friends; and when the family dines alone, the fore or hind quarter will make a reasonable dish, and seasoned with a little pepper or salt will be very good boiled on the fourth day, especially in winter.

--- a/_posts/2018-02-19-were-gonna-have-to-eat-the-kids.md
+++ b/_posts/2018-02-19-were-gonna-have-to-eat-the-kids.md
@@ -2,8 +2,8 @@
 layout: post
 title: Culture
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 I am assured by our merchants, that a boy or a girl before twelve years old is no salable commodity; and even when they come to this age they will not yield above three pounds, or three pounds and half-a-crown at most on the exchange; which cannot turn to account either to the parents or kingdom, the charge of nutriment and rags having been at least four times that value.

--- a/_posts/2018-02-25-jswifts-got-a-supply-chain-worked-out.md
+++ b/_posts/2018-02-25-jswifts-got-a-supply-chain-worked-out.md
@@ -2,8 +2,8 @@
 layout: post
 title: Science & Health
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 I have reckoned upon a medium that a child just born will weigh 12 pounds, and in a solar year, if tolerably nursed, increaseth to 28 pounds.

--- a/_posts/2018-02-25-jswifts-got-a-supply-chain-worked-out.md
+++ b/_posts/2018-02-25-jswifts-got-a-supply-chain-worked-out.md
@@ -1,0 +1,15 @@
+---
+layout: post
+title: Science & Health
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+I have reckoned upon a medium that a child just born will weigh 12 pounds, and in a solar year, if tolerably nursed, increaseth to 28 pounds.
+
+I grant this food will be somewhat dear, and therefore very proper for landlords, who, as they have already devoured most of the parents, seem to have the best title to the children.
+
+Infant's flesh will be in season throughout the year, but more plentiful in March, and a little before and after; for we are told by a grave author, an eminent French physician, that fish being a prolific diet, there are more children born in Roman Catholic countries about nine months after Lent than at any other season; therefore, reckoning a year after Lent, the markets will be more glutted than usual, because the number of popish infants is at least three to one in this kingdom: and therefore it will have one other collateral advantage, by lessening the number of papists among us.
+
+I have already computed the charge of nursing a beggar's child (in which list I reckon all cottagers, laborers, and four-fifths of the farmers) to be about two shillings per annum, rags included; and I believe no gentleman would repine to give ten shillings for the carcass of a good fat child, which, as I have said, will make four dishes of excellent nutritive meat, when he hath only some particular friend or his own family to dine with him. Thus the squire will learn to be a good landlord, and grow popular among his tenants; the mother will have eight shillings net profit, and be fit for work till she produces another child.

--- a/_posts/2018-03-10-cmon-a-true-patriot-would-eat-kids.md
+++ b/_posts/2018-03-10-cmon-a-true-patriot-would-eat-kids.md
@@ -2,8 +2,8 @@
 layout: post
 title: Identities
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 Those who are more thrifty (as I must confess the times require) may flay the carcass; the skin of which artificially dressed will make admirable gloves for ladies, and summer boots for fine gentlemen.

--- a/_posts/2018-03-10-cmon-a-true-patriot-would-eat-kids.md
+++ b/_posts/2018-03-10-cmon-a-true-patriot-would-eat-kids.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: Identities
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+Those who are more thrifty (as I must confess the times require) may flay the carcass; the skin of which artificially dressed will make admirable gloves for ladies, and summer boots for fine gentlemen.
+
+As to our city of Dublin, shambles may be appointed for this purpose in the most convenient parts of it, and butchers we may be assured will not be wanting; although I rather recommend buying the children alive, and dressing them hot from the knife, as we do roasting pigs.
+
+A very worthy person, a true lover of his country, and whose virtues I highly esteem, was lately pleased in discoursing on this matter to offer a refinement upon my scheme. He said that many gentlemen of this kingdom, having of late destroyed their deer, he conceived that the want of venison might be well supplied by the bodies of young lads and maidens, not exceeding fourteen years of age nor under twelve; so great a number of both sexes in every country being now ready to starve for want of work and service; and these to be disposed of by their parents, if alive, or otherwise by their nearest relations. But with due deference to so excellent a friend and so deserving a patriot, I cannot be altogether in his sentiments; for as to the males, my American acquaintance assured me, from frequent experience, that their flesh was generally tough and lean, like that of our schoolboys by continual exercise, and their taste disagreeable; and to fatten them would not answer the charge. Then as to the females, it would, I think, with humble submission be a loss to the public, because they soon would become breeders themselves; and besides, it is not improbable that some scrupulous people might be apt to censure such a practice (although indeed very unjustly), as a little bordering upon cruelty; which, I confess, hath always been with me the strongest objection against any project, however so well intended.

--- a/_posts/2018-03-13-it-happened-once-and-everyone-was-super-chill.md
+++ b/_posts/2018-03-13-it-happened-once-and-everyone-was-super-chill.md
@@ -2,8 +2,8 @@
 layout: post
 title: Energy & Environment
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 But in order to justify my friend, he confessed that this expedient was put into his head by the famous Psalmanazar, a native of the island Formosa, who came from thence to London above twenty years ago, and in conversation told my friend, that in his country when any young person happened to be put to death, the executioner sold the carcass to persons of quality as a prime dainty; and that in his time the body of a plump girl of fifteen, who was crucified for an attempt to poison the emperor, was sold to his imperial majesty's prime minister of state, and other great mandarins of the court, in joints from the gibbet, at four hundred crowns. Neither indeed can I deny, that if the same use were made of several plump young girls in this town, who without one single groat to their fortunes cannot stir abroad without a chair, and appear at playhouse and assemblies in foreign fineries which they never will pay for, the kingdom would not be the worse.

--- a/_posts/2018-03-13-it-happened-once-and-everyone-was-super-chill.md
+++ b/_posts/2018-03-13-it-happened-once-and-everyone-was-super-chill.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Energy & Environment
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+But in order to justify my friend, he confessed that this expedient was put into his head by the famous Psalmanazar, a native of the island Formosa, who came from thence to London above twenty years ago, and in conversation told my friend, that in his country when any young person happened to be put to death, the executioner sold the carcass to persons of quality as a prime dainty; and that in his time the body of a plump girl of fifteen, who was crucified for an attempt to poison the emperor, was sold to his imperial majesty's prime minister of state, and other great mandarins of the court, in joints from the gibbet, at four hundred crowns. Neither indeed can I deny, that if the same use were made of several plump young girls in this town, who without one single groat to their fortunes cannot stir abroad without a chair, and appear at playhouse and assemblies in foreign fineries which they never will pay for, the kingdom would not be the worse.
+
+Some persons of a desponding spirit are in great concern about that vast number of poor people, who are aged, diseased, or maimed, and I have been desired to employ my thoughts what course may be taken to ease the nation of so grievous an encumbrance. But I am not in the least pain upon that matter, because it is very well known that they are every day dying and rotting by cold and famine, and filth and vermin, as fast as can be reasonably expected. And as to the young laborers, they are now in as hopeful a condition; they cannot get work, and consequently pine away for want of nourishment, to a degree that if at any time they are accidentally hired to common labor, they have not strength to perform it; and thus the country and themselves are happily delivered from the evils to come.

--- a/_posts/2018-03-17-also-this-will-cut-down-on-catholics-for-some-reason.md
+++ b/_posts/2018-03-17-also-this-will-cut-down-on-catholics-for-some-reason.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: The Big Idea
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+I have too long digressed, and therefore shall return to my subject. I think the advantages by the proposal which I have made are obvious and many, as well as of the highest importance.
+
+For first, as I have already observed, it would greatly lessen the number of papists, with whom we are yearly overrun, being the principal breeders of the nation as well as our most dangerous enemies; and who stay at home on purpose with a design to deliver the kingdom to the Pretender, hoping to take their advantage by the absence of so many good protestants, who have chosen rather to leave their country than stay at home and pay tithes against their conscience to an episcopal curate.

--- a/_posts/2018-03-17-also-this-will-cut-down-on-catholics-for-some-reason.md
+++ b/_posts/2018-03-17-also-this-will-cut-down-on-catholics-for-some-reason.md
@@ -2,8 +2,8 @@
 layout: post
 title: The Big Idea
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 I have too long digressed, and therefore shall return to my subject. I think the advantages by the proposal which I have made are obvious and many, as well as of the highest importance.

--- a/_posts/2018-03-18-reasons-two-through-four.md
+++ b/_posts/2018-03-18-reasons-two-through-four.md
@@ -1,0 +1,13 @@
+---
+layout: post
+title: Technology
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+Secondly, The poorer tenants will have something valuable of their own, which by law may be made liable to distress and help to pay their landlord's rent, their corn and cattle being already seized, and money a thing unknown.
+
+Thirdly, Whereas the maintenance of an hundred thousand children, from two years old and upward, cannot be computed at less than ten shillings a-piece per annum, the nation's stock will be thereby increased fifty thousand pounds per annum, beside the profit of a new dish introduced to the tables of all gentlemen of fortune in the kingdom who have any refinement in taste. And the money will circulate among ourselves, the goods being entirely of our own growth and manufacture.
+
+Fourthly, The constant breeders, beside the gain of eight shillings sterling per annum by the sale of their children, will be rid of the charge of maintaining them after the first year.

--- a/_posts/2018-03-18-reasons-two-through-four.md
+++ b/_posts/2018-03-18-reasons-two-through-four.md
@@ -2,8 +2,8 @@
 layout: post
 title: Technology
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 Secondly, The poorer tenants will have something valuable of their own, which by law may be made liable to distress and help to pay their landlord's rent, their corn and cattle being already seized, and money a thing unknown.

--- a/_posts/2018-03-19-reasons-five-and-six.md
+++ b/_posts/2018-03-19-reasons-five-and-six.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: Business & Finance
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+Fifthly, This food would likewise bring great custom to taverns; where the vintners will certainly be so prudent as to procure the best receipts for dressing it to perfection, and consequently have their houses frequented by all the fine gentlemen, who justly value themselves upon their knowledge in good eating: and a skilful cook, who understands how to oblige his guests, will contrive to make it as expensive as they please.
+
+Sixthly, This would be a great inducement to marriage, which all wise nations have either encouraged by rewards or enforced by laws and penalties. It would increase the care and tenderness of mothers toward their children, when they were sure of a settlement for life to the poor babes, provided in some sort by the public, to their annual profit instead of expense. We should see an honest emulation among the married women, which of them could bring the fattest child to the market. Men would become as fond of their wives during the time of their pregnancy as they are now of their mares in foal, their cows in calf, their sows when they are ready to farrow; nor offer to beat or kick them (as is too frequent a practice) for fear of a miscarriage.

--- a/_posts/2018-03-19-reasons-five-and-six.md
+++ b/_posts/2018-03-19-reasons-five-and-six.md
@@ -2,8 +2,8 @@
 layout: post
 title: Business & Finance
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 Fifthly, This food would likewise bring great custom to taverns; where the vintners will certainly be so prudent as to procure the best receipts for dressing it to perfection, and consequently have their houses frequented by all the fine gentlemen, who justly value themselves upon their knowledge in good eating: and a skilful cook, who understands how to oblige his guests, will contrive to make it as expensive as they please.

--- a/_posts/2018-03-21-other-myriad-benefits.md
+++ b/_posts/2018-03-21-other-myriad-benefits.md
@@ -1,0 +1,11 @@
+---
+layout: post
+title: First Person
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+Many other advantages might be enumerated. For instance, the addition of some thousand carcasses in our exportation of barreled beef, the propagation of swine's flesh, and improvement in the art of making good bacon, so much wanted among us by the great destruction of pigs, too frequent at our tables; which are no way comparable in taste or magnificence to a well-grown, fat, yearling child, which roasted whole will make a considerable figure at a lord mayor's feast or any other public entertainment. But this and many others I omit, being studious of brevity.
+
+Supposing that one thousand families in this city, would be constant customers for infants flesh, besides others who might have it at merry meetings, particularly at weddings and christenings, I compute that Dublin would take off annually about twenty thousand carcasses; and the rest of the kingdom (where probably they will be sold somewhat cheaper) the remaining eighty thousand.

--- a/_posts/2018-03-21-other-myriad-benefits.md
+++ b/_posts/2018-03-21-other-myriad-benefits.md
@@ -2,8 +2,8 @@
 layout: post
 title: First Person
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 Many other advantages might be enumerated. For instance, the addition of some thousand carcasses in our exportation of barreled beef, the propagation of swine's flesh, and improvement in the art of making good bacon, so much wanted among us by the great destruction of pigs, too frequent at our tables; which are no way comparable in taste or magnificence to a well-grown, fat, yearling child, which roasted whole will make a considerable figure at a lord mayor's feast or any other public entertainment. But this and many others I omit, being studious of brevity.

--- a/_posts/2018-03-23-seriously-guys-theres-no-reason-not-to-eat-kids.md
+++ b/_posts/2018-03-23-seriously-guys-theres-no-reason-not-to-eat-kids.md
@@ -1,0 +1,9 @@
+---
+layout: post
+title: Video
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+I can think of no one objection, that will possibly be raised against this proposal, unless it should be urged, that the number of people will be thereby much lessened in the kingdom. This I freely own, and 'twas indeed one principal design in offering it to the world. I desire the reader will observe, that I calculate my remedy for this one individual Kingdom of Ireland, and for no other that ever was, is, or, I think, ever can be upon Earth. Therefore let no man talk to me of other expedients: Of taxing our absentees at five shillings a pound: Of using neither cloaths, nor houshold furniture, except what is of our own growth and manufacture: Of utterly rejecting the materials and instruments that promote foreign luxury: Of curing the expensiveness of pride, vanity, idleness, and gaming in our women: Of introducing a vein of parsimony, prudence and temperance: Of learning to love our country, wherein we differ even from Laplanders, and the inhabitants of Topinamboo: Of quitting our animosities and factions, nor acting any longer like the Jews, who were murdering one another at the very moment their city was taken: Of being a little cautious not to sell our country and consciences for nothing: Of teaching landlords to have at least one degree of mercy towards their tenants. Lastly, of putting a spirit of honesty, industry, and skill into our shop-keepers, who, if a resolution could now be taken to buy only our native goods, would immediately unite to cheat and exact upon us in the price, the measure, and the goodness, nor could ever yet be brought to make one fair proposal of just dealing, though often and earnestly invited to it.

--- a/_posts/2018-03-23-seriously-guys-theres-no-reason-not-to-eat-kids.md
+++ b/_posts/2018-03-23-seriously-guys-theres-no-reason-not-to-eat-kids.md
@@ -2,8 +2,8 @@
 layout: post
 title: Video
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 I can think of no one objection, that will possibly be raised against this proposal, unless it should be urged, that the number of people will be thereby much lessened in the kingdom. This I freely own, and 'twas indeed one principal design in offering it to the world. I desire the reader will observe, that I calculate my remedy for this one individual Kingdom of Ireland, and for no other that ever was, is, or, I think, ever can be upon Earth. Therefore let no man talk to me of other expedients: Of taxing our absentees at five shillings a pound: Of using neither cloaths, nor houshold furniture, except what is of our own growth and manufacture: Of utterly rejecting the materials and instruments that promote foreign luxury: Of curing the expensiveness of pride, vanity, idleness, and gaming in our women: Of introducing a vein of parsimony, prudence and temperance: Of learning to love our country, wherein we differ even from Laplanders, and the inhabitants of Topinamboo: Of quitting our animosities and factions, nor acting any longer like the Jews, who were murdering one another at the very moment their city was taken: Of being a little cautious not to sell our country and consciences for nothing: Of teaching landlords to have at least one degree of mercy towards their tenants. Lastly, of putting a spirit of honesty, industry, and skill into our shop-keepers, who, if a resolution could now be taken to buy only our native goods, would immediately unite to cheat and exact upon us in the price, the measure, and the goodness, nor could ever yet be brought to make one fair proposal of just dealing, though often and earnestly invited to it.

--- a/_posts/2018-04-01-youre-all-welcome-for-this-amazing-idea-kbye.md
+++ b/_posts/2018-04-01-youre-all-welcome-for-this-amazing-idea-kbye.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title: Podcasts
+categories:
+	- modest proposal
+	- flexible navigation
+---
+
+Therefore I repeat, let no man talk to me of these and the like expedients, 'till he hath at least some glympse of hope, that there will ever be some hearty and sincere attempt to put them into practice.
+
+But, as to my self, having been wearied out for many years with offering vain, idle, visionary thoughts, and at length utterly despairing of success, I fortunately fell upon this proposal, which, as it is wholly new, so it hath something solid and real, of no expence and little trouble, full in our own power, and whereby we can incur no danger in disobliging England. For this kind of commodity will not bear exportation, and flesh being of too tender a consistence, to admit a long continuance in salt, although perhaps I could name a country, which would be glad to eat up our whole nation without it.
+
+After all, I am not so violently bent upon my own opinion as to reject any offer proposed by wise men, which shall be found equally innocent, cheap, easy, and effectual. But before something of that kind shall be advanced in contradiction to my scheme, and offering a better, I desire the author or authors will be pleased maturely to consider two points. First, as things now stand, how they will be able to find food and raiment for an hundred thousand useless mouths and backs. And secondly, there being a round million of creatures in human figure throughout this kingdom, whose whole subsistence put into a common stock would leave them in debt two millions of pounds sterling, adding those who are beggars by profession to the bulk of farmers, cottagers, and laborers, with their wives and children who are beggars in effect: I desire those politicians who dislike my overture, and may perhaps be so bold as to attempt an answer, that they will first ask the parents of these mortals, whether they would not at this day think it a great happiness to have been sold for food, at a year old in the manner I prescribe, and thereby have avoided such a perpetual scene of misfortunes as they have since gone through by the oppression of landlords, the impossibility of paying rent without money or trade, the want of common sustenance, with neither house nor clothes to cover them from the inclemencies of the weather, and the most inevitable prospect of entailing the like or greater miseries upon their breed for ever.
+
+I profess, in the sincerity of my heart, that I have not the least personal interest in endeavoring to promote this necessary work, having no other motive than the public good of my country, by advancing our trade, providing for infants, relieving the poor, and giving some pleasure to the rich. I have no children by which I can propose to get a single penny; the youngest being nine years old, and my wife past child-bearing.
+
+The End

--- a/_posts/2018-04-01-youre-all-welcome-for-this-amazing-idea-kbye.md
+++ b/_posts/2018-04-01-youre-all-welcome-for-this-amazing-idea-kbye.md
@@ -2,8 +2,8 @@
 layout: post
 title: Podcasts
 categories:
-	- modest proposal
-	- flexible navigation
+- modest proposal
+- flexible navigation
 ---
 
 Therefore I repeat, let no man talk to me of these and the like expedients, 'till he hath at least some glympse of hope, that there will ever be some hearty and sincere attempt to put them into practice.

--- a/assets/css/_sass/_flexible-nav.scss
+++ b/assets/css/_sass/_flexible-nav.scss
@@ -17,18 +17,7 @@ ul[class*="flexnav"] {
 	list-style-type: none;
 }
 
-// ul, level 1
-.flexnav-main-grid {
-	position: relative;
-	height: 100%;
-	display: flex;
-	align-items: center;
-	text-align: center;
-}
-
-// li, level 1
-.flexnav__item {
-	padding-right: 1em;
+[class*="flexnav"][class*="__item"] {
 	a {
 		display: inline-block;
 		text-decoration: none;
@@ -43,23 +32,80 @@ ul[class*="flexnav"] {
 	}
 }
 
-// div
-.flexnav-more__prompt {
-	color: white;
+// ul, level 1
+.flexnav-main-grid {
+	position: relative;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	text-align: center;
+}
+
+// li, level 1
+.flexnav__item {
+	padding-right: 1em;
+/*	a {
+		display: inline-block;
+		text-decoration: none;
+		color: white;
+		-moz-transition: color .3s;
+		-webkit-transition: color .3s;
+		transition: color .3s;
+		white-space: nowrap;
+		&:hover, &:focus {
+			color: magenta;
+		}
+	} */
 }
 
 // li, level 1
 .flexnav__more-menu {
+	position: relative;
+//	align-self: flex-start;
+}
 
+// div
+.flexnav-more__prompt {
+	color: white;
+	height: 60px;
+	line-height: 60px;
+	&:hover, &:focus {
+		cursor: pointer;
+		color: magenta;
+	}
 }
 
 // ul, level 2
 .flexnav-more__wrapper {
+	position: absolute;
+	right: 0;
+	top: 0;
+	margin-top: 60px !important;
 	list-style-type: none;
+	text-align: left;
+	z-index: 1;
 	display: none;
+	opacity: 0;
+	-moz-transition: opacity .5s;
+	-webkit-transition: opacity .5s;
+	transition: opacity .5s;
 }
 
 // li, level 2
 .flexnav-more__item {
+	background-color: black;
+	a {
+		text-align: left !important;
+	}
+}
 
+/* Classes for JS: */
+
+.hidden {
+	display: none;
+}
+
+.show-more-menu {
+	display: initial;
+	opacity: 1;
 }

--- a/assets/css/_sass/_flexible-nav.scss
+++ b/assets/css/_sass/_flexible-nav.scss
@@ -1,15 +1,65 @@
 /* Flexible Navigation Styles: */
 
 .flexnav-wrapper {
-
+	position: relative;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 60px;
+	padding: 0 1rem;
+	border: 2px solid red;
+	background-color: black;
 }
 
-// ul
-.flexnav-main-content {
-
+ul[class*="flexnav"] {
+	margin: 0;
+	padding: 0;
+	list-style-type: none;
 }
 
-// li
+// ul, level 1
+.flexnav-main-grid {
+	position: relative;
+	height: 100%;
+	display: flex;
+	align-items: center;
+	text-align: center;
+}
+
+// li, level 1
 .flexnav__item {
+	padding-right: 1em;
+	a {
+		display: inline-block;
+		text-decoration: none;
+		color: white;
+		-moz-transition: color .3s;
+		-webkit-transition: color .3s;
+		transition: color .3s;
+		white-space: nowrap;
+		&:hover, &:focus {
+			color: magenta;
+		}
+	}
+}
+
+// div
+.flexnav-more__prompt {
+	color: white;
+}
+
+// li, level 1
+.flexnav__more-menu {
+
+}
+
+// ul, level 2
+.flexnav-more__wrapper {
+	list-style-type: none;
+	display: none;
+}
+
+// li, level 2
+.flexnav-more__item {
 
 }

--- a/assets/css/_sass/_flexible-nav.scss
+++ b/assets/css/_sass/_flexible-nav.scss
@@ -1,0 +1,15 @@
+/* Flexible Navigation Styles: */
+
+.flexnav-wrapper {
+
+}
+
+// ul
+.flexnav-main-content {
+
+}
+
+// li
+.flexnav__item {
+
+}

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -10,6 +10,7 @@
 @import "collection";
 @import "research";
 @import "navbar";
+@import "flexible-nav";
 
 /* Universal Styles: */
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,3 +1,69 @@
 (function() {
-	
+
+	// flexible-nav.html
+	(function() {
+		var menu 	  = document.querySelector(".flexnav-main-grid");
+		var menuItems = menu.children;
+		var prompt 	  = document.querySelector(".flexnav-more__prompt");
+		var moreList  = document.querySelector(".flexnav-more__wrapper");
+		var moreItems = moreList.children;
+
+		// display only # items that fit, hide rest in sub-menu
+		document.addEventListener("DOMContentLoaded", resizeMenu)
+
+		// repeat on resize
+		window.addEventListener("resize", resizeMenu)
+
+		// show/hide sub-menu
+		prompt.addEventListener("click", showSubMenu);
+
+		// function definitions:
+		function resizeMenu() {
+			// un-hide all items
+			for (let item of menuItems) {
+				item.classList.remove("hidden");
+			}
+			for (let item of moreItems) {
+				item.classList.remove("hidden");
+			}
+
+			var menuItemWidths = Array.from(menuItems, item => parseInt(item.offsetWidth));
+			var sumWidth 	   = 0;
+			var i 			   = -1;
+
+			// add more items to menu until run out of room
+			while (sumWidth < (menu.offsetWidth - prompt.offsetWidth)) {
+				i++;
+				sumWidth += menuItemWidths[i];
+			}
+			
+			// mark where that happens
+			var splitIndex 	  = i;
+
+			// hide post-split on main menu
+			for (i; i < (menuItems.length - 1); i++) {
+				menuItems[i].classList.add("hidden");
+			}
+			// hide pre-split on sub-menu
+			for (var j=0; j < splitIndex; j++) {
+				moreItems[j].classList.add("hidden");
+			}
+		}
+
+		function showSubMenu() {
+			// toggle if click directly
+			moreList.classList.toggle("show-more-menu");
+
+			// if showing and user clicks outside of it, hide again
+			if (moreList.classList.length == 2) {
+				window.addEventListener("click", function(e) {
+					if (e.target.classList.contains("flexnav-more__item") == false && 
+						e.target.classList.contains("flexnav-more__prompt") == false) {	
+						console.log("this is when it should hide again");
+						moreList.classList.remove("show-more-menu");
+					}	
+				});
+			}
+		} // end function definitions
+	})(); // end flexible-nav.html
 })();

--- a/pages/flexible-nav.html
+++ b/pages/flexible-nav.html
@@ -5,10 +5,18 @@ permalink: /flexible-nav/
 ---
 
 <div class="flexnav-wrapper">
-	<ul class="flexnav-main-content">
+	<ul class="flexnav-main-grid">
 	{% for post in site.posts %}
 		<li class="flexnav__item"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
 	{% endfor %}
+		<li class="flexnav__more-menu">
+			<div class="flexnav-more__prompt" aria-label="More menu items">More</div>
+			<ul class="flexnav-more__wrapper">
+			{% for post in site.posts %}
+				<li class="flexnav-more__item"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+			{% endfor %}
+			</ul>
+		</li>
 	</ul>
 </div>
 

--- a/pages/flexible-nav.html
+++ b/pages/flexible-nav.html
@@ -4,6 +4,14 @@ title: Flexible Navigation
 permalink: /flexible-nav/
 ---
 
+<div class="flexnav-wrapper">
+	<ul class="flexnav-main-content">
+	{% for post in site.posts %}
+		<li class="flexnav__item"><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
+	{% endfor %}
+	</ul>
+</div>
+
 
 <!-- page content to show with menu: -->
 {% assign fellows = site.pages | where_exp: "item", "item.title == 'Fellowship Layout'" %}

--- a/pages/flexible-nav.html
+++ b/pages/flexible-nav.html
@@ -3,3 +3,10 @@ layout: no-header
 title: Flexible Navigation
 permalink: /flexible-nav/
 ---
+
+
+<!-- page content to show with menu: -->
+{% assign fellows = site.pages | where_exp: "item", "item.title == 'Fellowship Layout'" %}
+{% for page in fellows %}
+	{{ page.content }}
+{% endfor %}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Number of links directly proportional to viewport width
- Any links that can't fit are put in a sub-menu under "More"
- If click that, can access those links
- Recalculates how many links can show on initial load and on resize

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
- Really liked how Vox did theirs, so essentially figured out how to recreate that effect
<!--- If it fixes an open issue, please link to the issue here. -->